### PR TITLE
Handle the case where no boards/stages/cards exist

### DIFF
--- a/constellation_orderboard/static/constellation_orderboard/css/orderboard.css
+++ b/constellation_orderboard/static/constellation_orderboard/css/orderboard.css
@@ -151,3 +151,7 @@ dialog + .backdrop {
 .stage-archived--true .archive-stage {
     display: none;
 }
+
+.fab {
+    text-decoration: none;
+}

--- a/constellation_orderboard/static/constellation_orderboard/js/manage-boards.js
+++ b/constellation_orderboard/static/constellation_orderboard/js/manage-boards.js
@@ -1,6 +1,7 @@
 /* global Handlebars componentHandler url_api_v1_board_list
-   url_view_board url_api_v1_board_archive url_api_v1_board_unarchive */
-/* exported archiveBoard unarchiveBoard */
+   url_view_board url_api_v1_board_archive url_api_v1_board_unarchive
+   url_board_edit */
+/* exported editBoard archiveBoard unarchiveBoard */
 
 /* Global board state */
 var boards_data;
@@ -18,8 +19,8 @@ $(document).ready(function(){
 /* Call APIs to get the JSON board_data */
 function getboard_data() {
   /* Get the list of stages */
+  boards_data = { active_boards: [], inactive_boards: [] };
   $.getJSON(url_api_v1_board_list, function(boards){
-    boards_data = { active_boards: [], inactive_boards: [] };
     for (var i = 0, len = boards.length; i < len; i++) {
       var board_array;
       if(boards[i].fields.archived == false) {
@@ -73,7 +74,7 @@ function archiveBoard(id) {
 
 /* edit a board */
 function editBoard(id) {
-    window.location.href = url_board_edit.replace(0, id);
+  window.location.href = url_board_edit.replace(0, id);
 }
 
 /* unarchive a board */
@@ -115,5 +116,8 @@ function addItem(event) {
       } else {
         message.MaterialSnackbar.showSnackbar({message: 'An error occured.'});
       }
+    })
+    .always(function() {
+      form_data.trigger('reset');
     });
 }

--- a/constellation_orderboard/static/constellation_orderboard/js/manage-stages.js
+++ b/constellation_orderboard/static/constellation_orderboard/js/manage-stages.js
@@ -19,8 +19,8 @@ $(document).ready(function(){
 /* Call APIs to get the JSON stage_data */
 function getstage_data() {
   /* Get the list of stages */
+  stages_data = {stages: []};
   $.getJSON(url_api_v1_stage_list, function(stages){
-    stages_data = {stages: []};
     for (var i = 0, len = stages.length; i < len; i++) {
       stages_data.stages[stages[i].fields.index] = {
         name: stages[i].fields.name,
@@ -144,5 +144,8 @@ function addItem(event) {
       } else {
         message.MaterialSnackbar.showSnackbar({message: 'An error occured.'});
       }
+    })
+    .always(function() {
+      form_data.trigger('reset');
     });
 }

--- a/constellation_orderboard/static/constellation_orderboard/js/orderboard.js
+++ b/constellation_orderboard/static/constellation_orderboard/js/orderboard.js
@@ -33,8 +33,8 @@ $(document).ready(function(){
 /* Call APIs to get the JSON board_data */
 function getboard_data() {
   /* Get the list of stages */
+  board_data = {mdl_width: 12, stages: []};
   $.getJSON(url_api_v1_stage_list, function(stages){
-    board_data = {mdl_width: 12, stages: []};
     /* Sort stages by their index field */
     stages.sort(function(a, b) {
       return a.fields.index - b.fields.index;
@@ -79,6 +79,7 @@ function getboard_data() {
         } else {
           message.MaterialSnackbar.showSnackbar({message: 'An error occured.'});
         }
+        renderTemplate(board_data);
       });
   })
     .fail(function(jqXHR) {
@@ -88,6 +89,7 @@ function getboard_data() {
       } else {
         message.MaterialSnackbar.showSnackbar({message: 'An error occured.'});
       }
+      renderTemplate(board_data);
     });
 }
 
@@ -178,6 +180,9 @@ function addItem(event) {
       } else {
         message.MaterialSnackbar.showSnackbar({message: 'An error occured.'});
       }
+    })
+    .always(function() {
+      form_data.trigger('reset');
     });
 }
 

--- a/constellation_orderboard/templates/constellation_orderboard/board.html
+++ b/constellation_orderboard/templates/constellation_orderboard/board.html
@@ -111,13 +111,18 @@
 <br/>
 <div class="divider"></div>
 {% endverbatim %}
-{% if can_add %}
 <div class="fixed-action-btn">
-    <button id="showNewItem" class="mdl-button mdl-js-button mdl-button--fab mdl-button--colored">
-        <i class="material-icons">add</i>
+  <a href="{% url 'view_board_archive' id %}" class="fab">
+    <button id="archive" class="mdl-button mdl-js-button mdl-button--fab mdl-button--accent">
+      <i class="material-icons">archive</i>
     </button>
+  </a>
+  {% if can_add %}
+  <button id="showNewItem" class="mdl-button mdl-js-button mdl-button--fab mdl-button--colored">
+    <i class="material-icons">add</i>
+  </button>
+  {% endif %}
 </div>
-{% endif %}
 
 <br/>
 {% endblock %}

--- a/constellation_orderboard/urls.py
+++ b/constellation_orderboard/urls.py
@@ -11,7 +11,8 @@ urlpatterns = [
         name="view_list"),
     url(r'^view/board/([\d]*)$', views.view_board,
         name="view_board"),
-    url(r'^view/board/([\d]*)/archive$', views.view_board_archive),
+    url(r'^view/board/([\d]*)/archive$', views.view_board_archive,
+        name="view_board_archive"),
 
 # =============================================================================
 # Management Routes

--- a/constellation_orderboard/util.py
+++ b/constellation_orderboard/util.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404
 from .models import Board
 
 
@@ -10,7 +11,7 @@ def board_permission(level):
     def decorator(view_function):
         @wraps(view_function)
         def _inner(request, board_id, *args, **kwargs):
-            board = Board.objects.get(pk=board_id)
+            board = get_object_or_404(Board, pk=board_id)
 
             if level == 'read':
                 group = list(set([board.readGroup,

--- a/constellation_orderboard/views.py
+++ b/constellation_orderboard/views.py
@@ -84,7 +84,7 @@ def view_board_archive(request, board_id):
 
 
 @login_required
-@permission_required('Board.create_board')
+@permission_required('constellation_orderboard.create_board')
 def manage_boards(request):
     template_settings_object = GlobalTemplateSettings(allowBackground=False)
     template_settings = template_settings_object.settings_dict()
@@ -111,7 +111,7 @@ def manage_board_edit(request, board_id):
 
 
 @login_required
-@permission_required('Stage.modify_stages')
+@permission_required('constellation_orderboard.modify_stages')
 def manage_stages(request):
     template_settings_object = GlobalTemplateSettings(allowBackground=False)
     template_settings = template_settings_object.settings_dict()


### PR DESCRIPTION
When there are no boards, stages, and cards defined, the page will still
act in a predictable manner, and now will show the first card added,
without needing a reload.

This also makes invalid board views 404.

Fixes 12